### PR TITLE
Envoyer une meilleur description lors d'exception InvalidUri avec un chemin interne

### DIFF
--- a/YamlHttpClient.Tests/YamlHttpClientFactoryTests.cs
+++ b/YamlHttpClient.Tests/YamlHttpClientFactoryTests.cs
@@ -224,6 +224,28 @@ namespace YamlHttpClient.Tests
             var demo = restService.BuildRequestMessage(new { test = "empty" });
         }
 
+        [TestMethod()]
+        [ExpectedException(typeof(YamlHttpClientException), "The URI should be invalid.")]
+        public async Task YamlHttpClientHandlerInvalidInternalUriSendAsyncTest()
+        {
+            var mock = new Mock<YamlHttpClientFactory>();
+            mock.CallBase = true;
+
+            mock.Setup(e => e.SendAsync(It.IsAny<HttpRequestMessage>(), It.IsAny<CancellationToken>())).ReturnsAsync(new HttpResponseMessage { Content = new StringContent("test") });
+
+            var services = new ServiceCollection();
+            services.AddTransient<IYamlHttpClientAccessor>(e => { return mock.Object; });
+
+            var provider = services.BuildServiceProvider();
+            var restService = provider.GetRequiredService<IYamlHttpClientAccessor>();
+
+            restService.HttpClientSettings = new HttpClientSettings { Method = "POST", Url = "/invalidUri", Content = new ContentSettings { JsonContent = "{}" } };
+            restService.HandlebarsProvider = YamlHttpClientFactory.CreateDefaultHandleBars();
+
+            var demo = restService.BuildRequestMessage(new { test = "empty" });
+            await mock.Object.SendAsync(demo);
+        }
+
         public static string fnStringConverterCodepage(string sText, string sCodepageIn = "ISO-8859-1", string sCodepageOut = "UTF-8")
         {
             string sResultado = string.Empty;

--- a/YamlHttpClient/YamlHttpClient.csproj
+++ b/YamlHttpClient/YamlHttpClient.csproj
@@ -10,7 +10,7 @@
 		<PackageProjectUrl>https://github.com/anisite/YamlHttpClient</PackageProjectUrl>
 		<RepositoryUrl>https://github.com/anisite/YamlHttpClient</RepositoryUrl>
 		<PackageLicenseFile>LICENSE</PackageLicenseFile>
-		<Version>1.0.7</Version>
+		<Version>1.0.8</Version>
 		<Description>Yaml config based .net HttpClient</Description>
 	</PropertyGroup>
 

--- a/YamlHttpClient/YamlHttpClientFactory.cs
+++ b/YamlHttpClient/YamlHttpClientFactory.cs
@@ -1,20 +1,11 @@
 ﻿using HandlebarsDotNet;
-using HandlebarsDotNet.IO;
-using Newtonsoft.Json;
 using System;
-using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
-using System.Numerics;
-using System.Runtime.CompilerServices;
-using System.Security.Cryptography;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-using YamlDotNet.Serialization;
-using YamlDotNet.Serialization.NamingConventions;
 using YamlHttpClient.Exceptions;
 using YamlHttpClient.Factory;
 using YamlHttpClient.Interfaces;
@@ -159,9 +150,7 @@ namespace YamlHttpClient
         /// <returns></returns>
         public virtual Task<HttpResponseMessage> SendAsync(HttpRequestMessage httpRequestMessage)
         {
-            var client = GetHttpClient();
-
-            return client.SendAsync(httpRequestMessage, CancellationToken.None);
+            return SendAsyncCore(httpRequestMessage, CancellationToken.None);
         }
 
         /// <summary>
@@ -172,9 +161,21 @@ namespace YamlHttpClient
         /// <returns></returns>
         public virtual Task<HttpResponseMessage> SendAsync(HttpRequestMessage httpRequestMessage, CancellationToken cancellationToken)
         {
+            return SendAsyncCore(httpRequestMessage, cancellationToken);
+        }
+
+        private Task<HttpResponseMessage> SendAsyncCore(HttpRequestMessage httpRequestMessage, CancellationToken cancellationToken)
+        {
             var client = GetHttpClient();
 
-            return client.SendAsync(httpRequestMessage, cancellationToken);
+            try
+            {
+                return client.SendAsync(httpRequestMessage, cancellationToken);
+            }
+            catch (InvalidOperationException ex)
+            {
+                throw new YamlHttpClientException($"Invalid URI : '{SS(HttpClientSettings.Url, httpRequestMessage.RequestUri)}'", ex);
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
Donner plus de détails sur l'URI invalide quand l'erreur survient comme l'URI en problème.